### PR TITLE
Adds .fromGit and buildLocal

### DIFF
--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -4,6 +4,12 @@ on:
     paths-ignore:
       - "**.md"
       - "LICENSE"
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - "**.md"
+      - "LICENSE"
 
 jobs:
   windows:

--- a/.github/workflows/test_publish.yml
+++ b/.github/workflows/test_publish.yml
@@ -1,9 +1,15 @@
-name: test publish to pub.dev and release
+name: test + publish + release
 
 on:
   push:
     # tags:
     #   - 'v[0-9]+.[0-9]+.[0-9]+*' # tag pattern on pub.dev: 'v{{version}'
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - "**.md"
+      - "LICENSE"
 
 jobs:
   test-linux:

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 # Files and directories created by pub
 .dart_tool/
 .packages
-build/
+**/build/**
 # If you're building an application, you may want to check-in your pubspec.lock
 pubspec.lock
 coverage/
@@ -36,6 +36,3 @@ doc/api/
 
 # External directory
 **/external/**
-
-# Local Build directories
-**/build_*/

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ doc/api/
 
 # External directory
 **/external/**
+
+# Local Build directories
+**/build_*/

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ doc/api/
 
 # FVM Version Cache
 .fvm/
+
+# External directory
+**/external/**

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -41,7 +41,7 @@ analyzer:
     parameter_assignments: error
     prefer_if_elements_to_conditional_expressions: ignore
 formatter:
-  pagewidth: 110
+  page_width: 110
 linter:
   rules:
     - always_declare_return_types

--- a/example/add/hook/build.dart
+++ b/example/add/hook/build.dart
@@ -7,6 +7,11 @@ import 'package:native_toolchain_cmake/native_toolchain_cmake.dart';
 void main(List<String> args) async {
   await build(args, (input, output) async {
     final sourceDir = Directory(await getPackagePath('add')).uri.resolve('src');
-    await runBuild(input, output, sourceDir);
+    const exampleGit = false;
+    if (!exampleGit) {
+      await runBuild(input, output, sourceDir);
+    } else {
+      await runBuildGit(input, output, sourceDir);
+    }
   });
 }

--- a/example/add/hook/build.dart
+++ b/example/add/hook/build.dart
@@ -7,7 +7,7 @@ import 'package:native_toolchain_cmake/native_toolchain_cmake.dart';
 void main(List<String> args) async {
   await build(args, (input, output) async {
     final sourceDir = Directory(await getPackagePath('add')).uri.resolve('src');
-    const exampleGit = true;
+    const exampleGit = false;
     if (!exampleGit) {
       await runBuild(input, output, sourceDir);
     } else {

--- a/example/add/hook/build.dart
+++ b/example/add/hook/build.dart
@@ -7,7 +7,7 @@ import 'package:native_toolchain_cmake/native_toolchain_cmake.dart';
 void main(List<String> args) async {
   await build(args, (input, output) async {
     final sourceDir = Directory(await getPackagePath('add')).uri.resolve('src');
-    const exampleGit = false;
+    const exampleGit = true;
     if (!exampleGit) {
       await runBuild(input, output, sourceDir);
     } else {

--- a/example/add/lib/src/hook_helpers/hook_helpers.dart
+++ b/example/add/lib/src/hook_helpers/hook_helpers.dart
@@ -4,22 +4,37 @@ import 'package:native_toolchain_cmake/native_toolchain_cmake.dart';
 
 const name = 'add';
 
-Future<void> runBuild(BuildInput input, BuildOutputBuilder output, Uri sourceDir) async {
-  final builder = CMakeBuilder.create(
-    name: name,
-    sourceDir: sourceDir,
-    buildMode: BuildMode.release,
-    defines: {
-      'CMAKE_INSTALL_PREFIX': input.outputDirectory.resolve('install').toFilePath(),
-    },
-    targets: ['install'],
-  );
+Future<void> runBuild(
+    BuildInput input, BuildOutputBuilder output, Uri sourceDir) async {
+  //final builder = CMakeBuilder.create(
+  //  name: name,
+  //  sourceDir: sourceDir,
+  //  defines: {
+  //    'CMAKE_BUILD_TYPE': 'Release',
+  //    'CMAKE_INSTALL_PREFIX': '${input.outputDirectory.toFilePath()}/install',
+  //  },
+  //  targets: ['install'],
+  //);
+
+  final builder = CMakeBuilder.createFromGit(
+      gitUrl: "https://github.com/rainyl/native_toolchain_cmake.git",
+      sourceDir: sourceDir,
+      name: name,
+      gitSubDir: "example/add/src",
+      defines: {
+        'CMAKE_BUILD_TYPE': 'Release',
+        'CMAKE_INSTALL_PREFIX': '${input.outputDirectory.toFilePath()}/install',
+      },
+      targets: [
+        'install'
+      ]);
+
   await builder.run(
     input: input,
     output: output,
     logger: Logger('')
       ..level = Level.ALL
-      ..onRecord.listen((record) => print(record.message)),
+      ..onRecord.listen((record) => stderr.writeln(record)),
   );
 
   final libPath = switch (input.config.code.targetOS) {

--- a/example/add/lib/src/hook_helpers/hook_helpers.dart
+++ b/example/add/lib/src/hook_helpers/hook_helpers.dart
@@ -11,24 +11,56 @@ Future<void> runBuild(
   BuildOutputBuilder output,
   Uri sourceDir,
 ) async {
-  // Local src directory
-  // final builder = CMakeBuilder.create(
-  //   name: name,
-  //   sourceDir: sourceDir,
-  //   defines: {
-  //     'CMAKE_BUILD_TYPE': 'Release',
-  //     'CMAKE_INSTALL_PREFIX': '${input.outputDirectory.toFilePath()}/install',
-  //   },
-  //   targets: [
-  //     'install',
-  //   ],
-  //   buildLocal: true,
-  //   logger: Logger('')
-  //     ..level = Level.ALL
-  //     // temp fwd to stderr until process logs pass to stdout
-  //     ..onRecord.listen((record) => stderr.writeln(record)),
-  // );
+  final builder = CMakeBuilder.create(
+    name: name,
+    sourceDir: sourceDir,
+    defines: {
+      'CMAKE_BUILD_TYPE': 'Release',
+      'CMAKE_INSTALL_PREFIX': '${input.outputDirectory.toFilePath()}/install',
+    },
+    targets: [
+      'install',
+    ],
+    buildLocal: true,
+    logger: Logger('')
+      ..level = Level.ALL
+      // temp fwd to stderr until process logs pass to stdout
+      ..onRecord.listen((record) => stderr.writeln(record)),
+  );
 
+  await builder.run(
+    input: input,
+    output: output,
+    logger: Logger('')
+      ..level = Level.ALL
+      ..onRecord.listen((record) => stderr.writeln(record)),
+  );
+
+  final libPath = switch (input.config.code.targetOS) {
+    OS.linux => "install/lib/libadd.so",
+    OS.macOS => "install/lib/libadd.dylib",
+    OS.windows => "install/lib/add.dll",
+    OS.android => "install/lib/libadd.so",
+    OS.iOS => "install/lib/libadd.dylib",
+    _ => throw UnsupportedError("Unsupported OS")
+  };
+  output.assets.code.add(
+    CodeAsset(
+      package: name,
+      name: '$name.dart',
+      linkMode: DynamicLoadingBundled(),
+      os: input.config.code.targetOS,
+      file: input.outputDirectory.resolve(libPath),
+      architecture: input.config.code.targetArchitecture,
+    ),
+  );
+}
+
+Future<void> runBuildGit(
+  BuildInput input,
+  BuildOutputBuilder output,
+  Uri sourceDir,
+) async {
   // From git url
   final builder = CMakeBuilder.fromGit(
     gitUrl: "https://github.com/rainyl/native_toolchain_cmake.git",

--- a/example/add/lib/src/hook_helpers/hook_helpers.dart
+++ b/example/add/lib/src/hook_helpers/hook_helpers.dart
@@ -61,6 +61,10 @@ Future<void> runBuildGit(
   BuildOutputBuilder output,
   Uri sourceDir,
 ) async {
+  final logger = Logger('')
+    ..level = Level.ALL
+    // temp fwd to stderr until process logs pass to stdout
+    ..onRecord.listen((record) => stderr.writeln(record));
   // From git url
   final builder = CMakeBuilder.fromGit(
     gitUrl: "https://github.com/rainyl/native_toolchain_cmake.git",
@@ -73,18 +77,13 @@ Future<void> runBuildGit(
     },
     targets: ['install'],
     buildLocal: true,
-    logger: Logger('')
-      ..level = Level.ALL
-      // temp fwd to stderr until process logs pass to stdout
-      ..onRecord.listen((record) => stderr.writeln(record)),
+    logger: logger,
   );
 
   await builder.run(
     input: input,
     output: output,
-    logger: Logger('')
-      ..level = Level.ALL
-      ..onRecord.listen((record) => stderr.writeln(record)),
+    logger: logger,
   );
 
   final libPath = switch (input.config.code.targetOS) {

--- a/example/add/lib/src/hook_helpers/hook_helpers.dart
+++ b/example/add/lib/src/hook_helpers/hook_helpers.dart
@@ -2,32 +2,50 @@ import 'package:logging/logging.dart';
 import 'package:native_assets_cli/code_assets_builder.dart';
 import 'package:native_toolchain_cmake/native_toolchain_cmake.dart';
 
+import 'dart:io';
+
 const name = 'add';
 
 Future<void> runBuild(
-    BuildInput input, BuildOutputBuilder output, Uri sourceDir) async {
-  //final builder = CMakeBuilder.create(
-  //  name: name,
-  //  sourceDir: sourceDir,
-  //  defines: {
-  //    'CMAKE_BUILD_TYPE': 'Release',
-  //    'CMAKE_INSTALL_PREFIX': '${input.outputDirectory.toFilePath()}/install',
-  //  },
-  //  targets: ['install'],
-  //);
+  BuildInput input,
+  BuildOutputBuilder output,
+  Uri sourceDir,
+) async {
+  // Local src directory
+  // final builder = CMakeBuilder.create(
+  //   name: name,
+  //   sourceDir: sourceDir,
+  //   defines: {
+  //     'CMAKE_BUILD_TYPE': 'Release',
+  //     'CMAKE_INSTALL_PREFIX': '${input.outputDirectory.toFilePath()}/install',
+  //   },
+  //   targets: [
+  //     'install',
+  //   ],
+  //   buildLocal: true,
+  //   logger: Logger('')
+  //     ..level = Level.ALL
+  //     // temp fwd to stderr until process logs pass to stdout
+  //     ..onRecord.listen((record) => stderr.writeln(record)),
+  // );
 
-  final builder = CMakeBuilder.createFromGit(
-      gitUrl: "https://github.com/rainyl/native_toolchain_cmake.git",
-      sourceDir: sourceDir,
-      name: name,
-      gitSubDir: "example/add/src",
-      defines: {
-        'CMAKE_BUILD_TYPE': 'Release',
-        'CMAKE_INSTALL_PREFIX': '${input.outputDirectory.toFilePath()}/install',
-      },
-      targets: [
-        'install'
-      ]);
+  // From git url
+  final builder = CMakeBuilder.fromGit(
+    gitUrl: "https://github.com/rainyl/native_toolchain_cmake.git",
+    sourceDir: sourceDir,
+    name: name,
+    gitSubDir: "example/add/src",
+    defines: {
+      'CMAKE_BUILD_TYPE': 'Release',
+      'CMAKE_INSTALL_PREFIX': '${input.outputDirectory.toFilePath()}/install',
+    },
+    targets: ['install'],
+    buildLocal: true,
+    logger: Logger('')
+      ..level = Level.ALL
+      // temp fwd to stderr until process logs pass to stdout
+      ..onRecord.listen((record) => stderr.writeln(record)),
+  );
 
   await builder.run(
     input: input,

--- a/example/add/lib/src/hook_helpers/hook_helpers.dart
+++ b/example/add/lib/src/hook_helpers/hook_helpers.dart
@@ -28,13 +28,7 @@ Future<void> runBuild(
       ..onRecord.listen((record) => stderr.writeln(record)),
   );
 
-  await builder.run(
-    input: input,
-    output: output,
-    logger: Logger('')
-      ..level = Level.ALL
-      ..onRecord.listen((record) => stderr.writeln(record)),
-  );
+  await builder.run(input: input, output: output);
 
   final libPath = switch (input.config.code.targetOS) {
     OS.linux => "install/lib/libadd.so",

--- a/lib/src/builder/builder.dart
+++ b/lib/src/builder/builder.dart
@@ -228,7 +228,6 @@ class CMakeBuilder implements Builder {
       'git',
       [
         'pull',
-        '--depth=1',
         'origin',
         gitBranch,
       ],
@@ -263,7 +262,7 @@ class CMakeBuilder implements Builder {
     required BuildOutputBuilder output,
     required Logger? logger,
   }) async {
-    final _logger = logger ?? this.logger ?? Logger('');
+    final _logger = logger ?? this.logger;
 
     if (buildLocal) {
       final plat = input.config.code.targetOS.name.toLowerCase();

--- a/lib/src/builder/builder.dart
+++ b/lib/src/builder/builder.dart
@@ -228,6 +228,7 @@ class CMakeBuilder implements Builder {
       'git',
       [
         'pull',
+        '--depth=1',
         'origin',
         gitBranch,
       ],
@@ -267,7 +268,7 @@ class CMakeBuilder implements Builder {
     if (buildLocal) {
       final plat = input.config.code.targetOS.name.toLowerCase();
       final arch = input.config.code.targetArchitecture.name.toLowerCase();
-      outDir = sourceDir.resolve('build_${plat}_$arch');
+      outDir = sourceDir.resolve('build/$plat/$arch');
     }
 
     await Directory.fromUri(outDir ?? input.outputDirectory)

--- a/lib/src/builder/builder.dart
+++ b/lib/src/builder/builder.dart
@@ -226,12 +226,7 @@ class CMakeBuilder implements Builder {
 
     final fetchProcess = Process.runSync(
       'git',
-      [
-        'pull',
-        '--depth=1',
-        'origin',
-        gitBranch,
-      ],
+      ['pull', '--depth=1', 'origin', gitBranch, gitCommit],
       workingDirectory: dirPath,
     );
     logger?.log(Level.INFO, 'git fetch: ${fetchProcess.stdout}');

--- a/lib/src/builder/builder.dart
+++ b/lib/src/builder/builder.dart
@@ -6,13 +6,12 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:logging/logging.dart';
 import 'package:native_assets_cli/code_assets_builder.dart';
-import 'package:native_toolchain_cmake/src/utils/run_process.dart';
 
+import '../utils/run_process.dart';
 import 'build_mode.dart';
 import 'generator.dart';
 import 'log_level.dart';
@@ -203,14 +202,14 @@ class CMakeBuilder implements Builder {
       Uri.directory("${sourceDir.toFilePath()}/external/$name"),
     )..createSync(recursive: true);
     final dirPath = newDir.path;
-    final initProcess = Process.runSync(
-      'git',
-      [
-        'init',
-      ],
-      workingDirectory: dirPath,
+
+    runProcessSync(
+      executable: 'git',
+      arguments: ['init'],
+      workingDirectory: newDir.uri,
+      throwOnUnexpectedExitCode: true,
+      logger: logger,
     );
-    logger?.log(Level.INFO, 'git init: ${initProcess.stdout}');
 
     final remoteAddProcess = Process.runSync(
       'git',
@@ -256,7 +255,7 @@ class CMakeBuilder implements Builder {
   Future<void> run({
     required BuildInput input,
     required BuildOutputBuilder output,
-    required Logger? logger,
+    Logger? logger,
   }) async {
     final _logger = logger ?? this.logger;
 

--- a/lib/src/native_toolchain/recognizer.dart
+++ b/lib/src/native_toolchain/recognizer.dart
@@ -27,8 +27,7 @@ class CompilerRecognizer implements ToolResolver {
     if (filePath.contains('-gcc')) {
       tool = gcc;
     } else if (filePath.endsWith(os.executableFileName('clang'))) {
-      final stdout = await CliFilter.executeCli(uri,
-          arguments: ['--version'], logger: logger);
+      final stdout = await CliFilter.executeCli(uri, arguments: ['--version'], logger: logger);
       if (stdout.contains('Apple clang')) {
         tool = appleClang;
       } else {

--- a/lib/src/native_toolchain/xcode.dart
+++ b/lib/src/native_toolchain/xcode.dart
@@ -91,8 +91,7 @@ class XCodeSdkResolver implements ToolResolver {
     assert(result.exitCode == 0);
     final uriSymbolic = Uri.directory(result.stdout.trim());
     logger?.fine('Found $sdk at ${uriSymbolic.toFilePath()}');
-    final uri = Uri.directory(
-        await Directory.fromUri(uriSymbolic).resolveSymbolicLinks());
+    final uri = Uri.directory(await Directory.fromUri(uriSymbolic).resolveSymbolicLinks());
     if (uriSymbolic != uri) {
       logger?.fine('Found $sdk at ${uri.toFilePath()}');
     }

--- a/lib/src/tool/tool_instance.dart
+++ b/lib/src/tool/tool_instance.dart
@@ -68,10 +68,7 @@ class ToolInstance implements Comparable<ToolInstance> {
 
   @override
   bool operator ==(Object other) =>
-      other is ToolInstance &&
-      tool == other.tool &&
-      uri == other.uri &&
-      version == other.version;
+      other is ToolInstance && tool == other.tool && uri == other.uri && version == other.version;
 
   @override
   int get hashCode => Object.hash(tool, uri, version);

--- a/lib/src/tool/tool_requirement.dart
+++ b/lib/src/tool/tool_requirement.dart
@@ -28,8 +28,7 @@ class ToolRequirement implements Requirement {
   });
 
   @override
-  String toString() =>
-      'ToolRequirement(${tool.name}, minimumVersion: $minimumVersion)';
+  String toString() => 'ToolRequirement(${tool.name}, minimumVersion: $minimumVersion)';
 
   @override
   List<ToolInstance>? satisfy(List<ToolInstance> availableToolInstances) {

--- a/lib/src/utils/run_process.dart
+++ b/lib/src/utils/run_process.dart
@@ -22,8 +22,7 @@ Future<RunProcessResult> runProcess({
   int expectedExitCode = 0,
   bool throwOnUnexpectedExitCode = false,
 }) async {
-  final printWorkingDir =
-      workingDirectory != null && workingDirectory != Directory.current.uri;
+  final printWorkingDir = workingDirectory != null && workingDirectory != Directory.current.uri;
   final commandString = [
     if (printWorkingDir) '(cd ${workingDirectory.toFilePath()};',
     ...?environment?.entries.map((entry) => '${entry.key}=${entry.value}'),
@@ -72,11 +71,8 @@ Future<RunProcessResult> runProcess({
     },
   );
 
-  final (exitCode, _, _) = await (
-    process.exitCode,
-    stdoutSub.asFuture<void>(),
-    stderrSub.asFuture<void>()
-  ).wait;
+  final (exitCode, _, _) =
+      await (process.exitCode, stdoutSub.asFuture<void>(), stderrSub.asFuture<void>()).wait;
 
   await stdoutSub.cancel();
   await stderrSub.cancel();
@@ -110,8 +106,7 @@ RunProcessResult runProcessSync({
   int expectedExitCode = 0,
   bool throwOnUnexpectedExitCode = false,
 }) {
-  final printWorkingDir =
-      workingDirectory != null && workingDirectory != Directory.current.uri;
+  final printWorkingDir = workingDirectory != null && workingDirectory != Directory.current.uri;
   final commandString = [
     if (printWorkingDir) '(cd ${workingDirectory.toFilePath()};',
     ...?environment?.entries.map((entry) => '${entry.key}=${entry.value}'),

--- a/test/builder/cmake_builder_git_test.dart
+++ b/test/builder/cmake_builder_git_test.dart
@@ -1,0 +1,105 @@
+import 'dart:io';
+import 'package:test/test.dart';
+import 'package:logging/logging.dart';
+import 'package:native_toolchain_cmake/native_toolchain_cmake.dart';
+import 'package:native_toolchain_cmake/src/builder/builder.dart';
+import 'package:native_assets_cli/code_assets_builder.dart';
+
+void main() {
+  group('CMakeBuilder.fromGit', () {
+    late Directory tempDir;
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('cmake_builder_git_test');
+    });
+
+    tearDown(() {
+      if (tempDir.existsSync()) {
+        tempDir.deleteSync(recursive: true);
+      }
+    });
+
+    test('should create external directory for git clone', () {
+      final sourceDir = Uri.directory(tempDir.path + Platform.pathSeparator);
+      // Instantiate builder with a non-empty gitSubDir so that the external directory gets created.
+      final builder = CMakeBuilder.fromGit(
+        name: 'add',
+        gitUrl: 'https://github.com/rainyl/native_toolchain_cmake.git',
+        sourceDir: sourceDir,
+        gitSubDir: 'example/add/src',
+      );
+
+      // The builder constructor creates a directory at sourceDir/external/<name>
+      final extDir = Directory(
+          '${tempDir.path}${Platform.pathSeparator}external${Platform.pathSeparator}add');
+      expect(extDir.existsSync(), isTrue,
+          reason: 'External directory should be created.');
+    });
+  });
+
+  group('CMakeBuilder.run', () {
+    late Directory tempDir;
+    setUp(() {
+      tempDir =
+          Directory.systemTemp.createTempSync('cmake_builder_git_run_test');
+    });
+    tearDown(() {
+      if (tempDir.existsSync()) {
+        tempDir.deleteSync(recursive: true);
+      }
+    });
+
+    test('should create output directory when buildLocal is set', () async {
+      final sourceDir = Uri.directory(tempDir.path + Platform.pathSeparator);
+      // Create builder with buildLocal true.
+      final builder = CMakeBuilder.fromGit(
+        name: 'add',
+        gitUrl: 'https://github.com/rainyl/native_toolchain_cmake.git',
+        sourceDir: sourceDir,
+        gitSubDir: '',
+        buildLocal: true,
+      );
+
+      // Use real build input/output objects.
+      final buildInputBuilder = BuildInputBuilder()
+        ..setupShared(
+          packageName: 'add',
+          packageRoot: sourceDir,
+          outputFile: sourceDir.resolve('output.json'),
+          outputDirectory: sourceDir,
+          outputDirectoryShared: sourceDir,
+        )
+        ..config.setupBuild(
+          linkingEnabled: false,
+          dryRun: false,
+        )
+        ..config.setupShared(
+          buildAssetTypes: [CodeAsset.type],
+        )
+        ..config.setupCode(
+          targetOS: OS.current,
+          targetArchitecture: Architecture.current,
+          linkModePreference: LinkModePreference.dynamic,
+        );
+      final input = BuildInput(buildInputBuilder.json);
+      final output = BuildOutputBuilder();
+
+      // Run the builder.
+      try {
+        await builder.run(input: input, output: output, logger: Logger('Test'));
+      } catch (_) {
+        // Ignore errors from running external tools.
+      }
+
+      // The builder.run method should set outDir under sourceDir/build/<os>/<arch>
+      final osName = input.config.code.targetOS.name.toLowerCase();
+      final archName = input.config.code.targetArchitecture.name.toLowerCase();
+      final buildDir = Directory(
+          '${tempDir.path}${Platform.pathSeparator}build${Platform.pathSeparator}$osName${Platform.pathSeparator}$archName');
+      expect(
+        buildDir.existsSync(),
+        isTrue,
+        reason: 'Build directory should be created when buildLocal is true.',
+      );
+    });
+  });
+}

--- a/test/builder/cmake_builder_git_test.dart
+++ b/test/builder/cmake_builder_git_test.dart
@@ -1,105 +1,106 @@
+import 'dart:ffi';
 import 'dart:io';
-import 'package:test/test.dart';
-import 'package:logging/logging.dart';
+
 import 'package:native_toolchain_cmake/native_toolchain_cmake.dart';
 import 'package:native_toolchain_cmake/src/builder/builder.dart';
-import 'package:native_assets_cli/code_assets_builder.dart';
+import 'package:test/test.dart';
+
+import '../helpers.dart';
 
 void main() {
+  final targetOS = OS.current;
+  final macOSConfig = targetOS == OS.macOS ? MacOSCodeConfig(targetVersion: defaultMacOSVersion) : null;
+
   group('CMakeBuilder.fromGit', () {
-    late Directory tempDir;
-    setUp(() {
-      tempDir = Directory.systemTemp.createTempSync('cmake_builder_git_test');
-    });
+    for (final subdir in ['', 'example/add/src']) {
+      test('create external dir with subdir=$subdir', () async {
+        final tempDir = await tempDirForTest();
+        // Instantiate builder with a non-empty gitSubDir so that the external directory gets created.
+        final builder = CMakeBuilder.fromGit(
+          name: 'add',
+          gitUrl: 'https://github.com/rainyl/native_toolchain_cmake.git',
+          sourceDir: tempDir,
+          gitSubDir: subdir,
+          // logger: Logger('')..level = Level.ALL..onRecord.listen((record) => stderr.writeln(record)),
+        );
 
-    tearDown(() {
-      if (tempDir.existsSync()) {
-        tempDir.deleteSync(recursive: true);
-      }
-    });
-
-    test('should create external directory for git clone', () {
-      final sourceDir = Uri.directory(tempDir.path + Platform.pathSeparator);
-      // Instantiate builder with a non-empty gitSubDir so that the external directory gets created.
-      final builder = CMakeBuilder.fromGit(
-        name: 'add',
-        gitUrl: 'https://github.com/rainyl/native_toolchain_cmake.git',
-        sourceDir: sourceDir,
-        gitSubDir: 'example/add/src',
-      );
-
-      // The builder constructor creates a directory at sourceDir/external/<name>
-      final extDir = Directory(
-          '${tempDir.path}${Platform.pathSeparator}external${Platform.pathSeparator}add');
-      expect(extDir.existsSync(), isTrue,
-          reason: 'External directory should be created.');
-    });
+        // The builder constructor creates a directory at sourceDir/external/<name>
+        expect(builder.cmakeListsDir, tempDir.resolve('external/add/').resolve(subdir).normalizePath());
+        final extDir = Directory.fromUri(tempDir.resolve('external/add/').resolve(subdir).normalizePath());
+        expect(extDir.existsSync(), isTrue, reason: 'External directory should be created.');
+        expect(extDir.listSync(), isNotEmpty);
+      });
+    }
   });
 
   group('CMakeBuilder.run', () {
-    late Directory tempDir;
-    setUp(() {
-      tempDir =
-          Directory.systemTemp.createTempSync('cmake_builder_git_run_test');
-    });
-    tearDown(() {
-      if (tempDir.existsSync()) {
-        tempDir.deleteSync(recursive: true);
-      }
-    });
+    for (final buildLocal in [true, false]) {
+      test('buildLocal=$buildLocal', () async {
+        final tempDir = await tempDirForTest();
+        final logMessages = <String>[];
+        final logger = createCapturingLogger(logMessages);
 
-    test('should create output directory when buildLocal is set', () async {
-      final sourceDir = Uri.directory(tempDir.path + Platform.pathSeparator);
-      // Create builder with buildLocal true.
-      final builder = CMakeBuilder.fromGit(
-        name: 'add',
-        gitUrl: 'https://github.com/rainyl/native_toolchain_cmake.git',
-        sourceDir: sourceDir,
-        gitSubDir: '',
-        buildLocal: true,
-      );
-
-      // Use real build input/output objects.
-      final buildInputBuilder = BuildInputBuilder()
-        ..setupShared(
-          packageName: 'add',
-          packageRoot: sourceDir,
-          outputFile: sourceDir.resolve('output.json'),
-          outputDirectory: sourceDir,
-          outputDirectoryShared: sourceDir,
-        )
-        ..config.setupBuild(
-          linkingEnabled: false,
-          dryRun: false,
-        )
-        ..config.setupShared(
-          buildAssetTypes: [CodeAsset.type],
-        )
-        ..config.setupCode(
-          targetOS: OS.current,
-          targetArchitecture: Architecture.current,
-          linkModePreference: LinkModePreference.dynamic,
+        // Create builder with buildLocal true.
+        final builder = CMakeBuilder.fromGit(
+          name: 'add',
+          gitUrl: 'https://github.com/rainyl/native_toolchain_cmake.git',
+          sourceDir: tempDir,
+          gitSubDir: 'example/add/src',
+          buildLocal: buildLocal,
+          logger: logger,
+          defines: {
+            'CMAKE_INSTALL_PREFIX': 'install',
+          },
+          targets: ['install'],
         );
-      final input = BuildInput(buildInputBuilder.json);
-      final output = BuildOutputBuilder();
 
-      // Run the builder.
-      try {
-        await builder.run(input: input, output: output, logger: Logger('Test'));
-      } catch (_) {
-        // Ignore errors from running external tools.
-      }
+        // Use real build input/output objects.
+        final buildInputBuilder = BuildInputBuilder()
+          ..setupShared(
+            packageName: 'add',
+            packageRoot: tempDir,
+            outputFile: tempDir.resolve('output.json'),
+            outputDirectory: tempDir,
+            outputDirectoryShared: tempDir,
+          )
+          ..config.setupBuild(
+            linkingEnabled: false,
+            dryRun: false,
+          )
+          ..config.setupShared(
+            buildAssetTypes: [CodeAsset.type],
+          )
+          ..config.setupCode(
+            targetOS: targetOS,
+            macOS: macOSConfig,
+            targetArchitecture: Architecture.current,
+            linkModePreference: LinkModePreference.dynamic,
+          );
+        final input = BuildInput(buildInputBuilder.json);
+        final output = BuildOutputBuilder();
 
-      // The builder.run method should set outDir under sourceDir/build/<os>/<arch>
-      final osName = input.config.code.targetOS.name.toLowerCase();
-      final archName = input.config.code.targetArchitecture.name.toLowerCase();
-      final buildDir = Directory(
-          '${tempDir.path}${Platform.pathSeparator}build${Platform.pathSeparator}$osName${Platform.pathSeparator}$archName');
-      expect(
-        buildDir.existsSync(),
-        isTrue,
-        reason: 'Build directory should be created when buildLocal is true.',
-      );
-    });
+        // Run the builder.
+        await builder.run(input: input, output: output);
+
+        // The builder.run method should set outDir under sourceDir/build/<os>/<arch>
+        final osName = input.config.code.targetOS.name.toLowerCase();
+        final archName = input.config.code.targetArchitecture.name.toLowerCase();
+        final buildDir = buildLocal
+            ? Directory.fromUri(tempDir.resolve('build/').resolve(osName).resolve(archName).normalizePath())
+            : Directory.fromUri(input.outputDirectory);
+        expect(
+          buildDir.existsSync(),
+          isTrue,
+          reason: 'Build directory should be created when buildLocal is true.',
+        );
+
+        // check built libs
+        final dylibUri = buildDir.uri.resolve('install/lib/${OS.current.dylibFileName('add')}');
+        expect(File.fromUri(dylibUri).existsSync(), true);
+        final dylib = openDynamicLibraryForTest(dylibUri.toFilePath());
+        final add = dylib.lookupFunction<Int32 Function(Int32, Int32), int Function(int, int)>('math_add');
+        expect(add(1, 2), 3);
+      });
+    }
   });
 }

--- a/test/tool/tool_test.dart
+++ b/test/tool/tool_test.dart
@@ -15,7 +15,7 @@ void main() {
     final resolver = PathToolResolver(toolName: 'cmake', executableName: 'cmake');
     final tools = await resolver.resolve(logger: null);
     expect(tools.length, greaterThan(0));
-    expect(await Directory.fromUri(tools.first.uri).exists(), true);
+    expect(File.fromUri(tools.first.uri).existsSync(), true);
   });
 
   test('equals and hashCode', () async {

--- a/test/tool/tool_test.dart
+++ b/test/tool/tool_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:native_toolchain_cmake/src/native_toolchain/android_ndk.dart';
 import 'package:native_toolchain_cmake/src/native_toolchain/clang.dart';
 import 'package:native_toolchain_cmake/src/tool/tool.dart';
@@ -13,7 +15,7 @@ void main() {
     final resolver = PathToolResolver(toolName: 'cmake', executableName: 'cmake');
     final tools = await resolver.resolve(logger: null);
     expect(tools.length, greaterThan(0));
-    print(tools.first.uri.toFilePath());
+    expect(await Directory.fromUri(tools.first.uri).exists(), true);
   });
 
   test('equals and hashCode', () async {


### PR DESCRIPTION
This adds a new factory fromGit and a flag that can be passed to both factories buildLocal. Had to manually init the directory instead of clone it so that we have control over the name of the directory the sources are pulled to.

Not sure how you want to split the example, added line comments to the add project's build hook for now.

I looked at adding a test but there are currently many failures with the defaults, these are mostly imported from the _c library?

closes #5 