### PR TITLE
track addedAssets, prevent duplicates, streamline extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # native_toolchain_cmake
 
+## 0.0.4
+
+- new: add extension methods `BuildOutputBuilder.findCodeAssets`, `BuildOutputBuilder.addAllCodeAssets`
+- breaking change: `BuildOutputBuilder.findAndAddCodeAssets` now returns `List<CodeAsset>`
+
 ## 0.0.3
 
 - new: add `CMakeBuilder.fromGit` constructor to create a builder from a remote repository.

--- a/lib/src/utils/add_assets.dart
+++ b/lib/src/utils/add_assets.dart
@@ -7,106 +7,108 @@ import 'package:path/path.dart' as p;
 
 import '../builder/linkmode.dart';
 
-/// Searches recursively through the provided [outDir] (or [input.outputDirectory]
-/// if not provided) for native library files that match the given [names]
-/// and adds them to [output.assets.code].
-///
-/// [names] are used to map a found library file to package URI.
-/// e.g., for `foo_windows_x64.dll` -> `package:my_pkg/native_foo.dart`,
-/// should provide `{'foo_windows_x64': 'native_foo.dart'}`.
-///
-/// If [regExp] is true, keys in [names] are treated as regular expression patterns to match library filenames.
-/// Use regExp if the built libraries are something like `libadd-1.dll`.
-/// e.g.,
-/// ```dart
-/// {r'(lib)?add-\d\.(dll|so|dylib)': 'native_foo.dart'}.
-/// ```
-///
-/// The expected filename is computed using the current operating system's naming conventions
-/// combined with a concrete [LinkMode] derived from [input.config.code.linkModePreference].
-/// For each file that ends with the computed library filename for one of the provided [names],
-/// a [CodeAsset] is created and added to [output.assets.code] if it hasn't already been added.
-///
-/// Duplicate assets are avoided by tracking previously added file paths internally
-/// as [output.assets] is not iterable.
-///
-/// Returns a list of URIs corresponding to all the added code assets.
-///
-/// Example:
-/// ```dart
-/// final foundUris = await addCodeAssets(
-///   input,
-///   output,
-///   outDir: myOutputUri,
-///   names: {'add': 'add.dart'},
-/// );
-/// ```
-///
-/// ```dart
-/// final foundUris = await addCodeAssets(
-///   input,
-///   output,
-///   outDir: myOutputUri,
-///   names: { r'(lib)?add\.(dll|so|dylib)': 'add.dart' },
-///   regExp=true,
-/// );
-/// ```
-Future<List<Uri>> addFoundCodeAssets(
-  BuildInput input,
-  BuildOutputBuilder output, {
-  required Map<String, String> names, // key: search library name, value: dart ffi name
-  Uri? outDir,
-  Logger? logger,
-  bool regExp = false,
-}) async {
-  final preferredMode = input.config.code.linkModePreference;
-  final searchDir = Directory.fromUri(outDir ?? input.outputDirectory);
-  final linkMode = getLinkMode(preferredMode);
-  final List<Uri> foundFiles = [];
-
-  logger?.info('Searching for libraries in ${searchDir.path}');
-  logger?.info('Preferred link mode: $preferredMode');
-
-  await for (final entity in searchDir.list(recursive: true, followLinks: false)) {
-    if (entity is! File) continue;
-    for (final MapEntry(:key, value: name) in names.entries) {
-      // even on windows, library name may be `libadd.dll` instead of `add.dll` sometimes,
-      // e.g., when using mingw64, so allow using RegExp matching if regExp=true.
-      final found = regExp
-          ? RegExp(key).hasMatch(p.basename(entity.path))
-          : entity.path.endsWith(OS.current.libraryFileName(key, linkMode));
-      if (!found) continue;
-      logger?.info('Found library file: ${entity.path}');
-      output.addCodeAsset(
-        CodeAsset(
-          package: input.packageName,
-          name: name,
-          linkMode: linkMode,
-          os: input.config.code.targetOS,
-          file: entity.uri,
-          architecture: input.config.code.targetArchitecture,
-        ),
-      );
-      foundFiles.add(entity.uri);
-      break; // only add one file per name
-    }
-  }
-  return foundFiles;
-}
-
 extension BuildOutputBuilderCodeAssets on BuildOutputBuilder {
-  /// short for [assets.code.add]
-  void addCodeAsset(CodeAsset codeAsset) {
-    assets.code.add(codeAsset);
-  }
+  static final Expando<Set<Uri>> _addedAssets = Expando<Set<Uri>>();
 
-  /// extension method for [addFoundCodeAssets]
+  Set<Uri> get addedAssets => _addedAssets[this] ??= <Uri>{};
+
+  /// Searches recursively through the provided [outDir] (or [input.outputDirectory]
+  /// if not provided) for native library files that match the given [names]
+  /// and adds them to [output.assets.code].
+  ///
+  /// [names] are used to map a found library file to package URI.
+  /// e.g., for `foo_windows_x64.dll` -> `package:my_pkg/native_foo.dart`,
+  /// should provide `{'foo_windows_x64': 'native_foo.dart'}`.
+  ///
+  /// If [regExp] is true, keys in [names] are treated as regular expression patterns to match library filenames.
+  /// Use regExp if the built libraries are something like `libadd-1.dll`.
+  /// e.g.,
+  /// ```dart
+  /// {r'(lib)?add-\d\.(dll|so|dylib)': 'native_foo.dart'}.
+  /// ```
+  ///
+  /// The expected filename is computed using the current operating system's naming conventions
+  /// combined with a concrete [LinkMode] derived from [input.config.code.linkModePreference].
+  /// For each file that ends with the computed library filename for one of the provided [names],
+  /// a [CodeAsset] is created and added to [output.assets.code] if it hasn't already been added.
+  ///
+  /// Duplicate assets are avoided by tracking previously added file paths internally
+  /// as [output.assets] is not iterable.
+  ///
+  /// Returns a list of URIs corresponding to all the added code assets.
+  ///
+  /// Example:
+  /// ```dart
+  /// final foundUris = await addCodeAssets(
+  ///   input,
+  ///   output,
+  ///   outDir: myOutputUri,
+  ///   names: {'add': 'add.dart'},
+  /// );
+  /// ```
+  ///
+  /// ```dart
+  /// final foundUris = await addCodeAssets(
+  ///   input,
+  ///   output,
+  ///   outDir: myOutputUri,
+  ///   names: { r'(lib)?add\.(dll|so|dylib)': 'add.dart' },
+  ///   regExp=true,
+  /// );
+  /// ```
   Future<List<Uri>> findAndAddCodeAssets(
     BuildInput input, {
-    required Map<String, String> names,
+    required Map<String, String> names, // key: search library name, value: dart ffi name
     Uri? outDir,
     Logger? logger,
     bool regExp = false,
-  }) async =>
-      addFoundCodeAssets(input, this, names: names, outDir: outDir, logger: logger, regExp: regExp);
+  }) async {
+    final preferredMode = input.config.code.linkModePreference;
+    final searchDir = Directory.fromUri(outDir ?? input.outputDirectory);
+    final linkMode = getLinkMode(preferredMode);
+    final List<Uri> foundFiles = [];
+    // Track the added asset names to prevent duplicates even if the file URIs differ.
+    final Set<String> addedAssetNames = {};
+
+    logger?.info('Searching for libraries in ${searchDir.path}');
+    logger?.info('Preferred link mode: $preferredMode');
+
+    await for (final entity in searchDir.list(recursive: true, followLinks: false)) {
+      if (entity is! File) continue;
+      for (final entry in names.entries) {
+        final key = entry.key;
+        final assetName = entry.value;
+        // Skip if we've already added an asset with this name.
+        if (addedAssetNames.contains(assetName)) continue;
+        final fileName = p.basename(entity.path);
+        final found = regExp
+            ? RegExp(key).hasMatch(fileName)
+            : entity.path.endsWith(OS.current.libraryFileName(key, linkMode));
+        if (!found) continue;
+        logger?.info('Found library file: ${entity.path}');
+        addCodeAsset(
+          CodeAsset(
+            package: input.packageName,
+            name: assetName,
+            linkMode: linkMode,
+            os: input.config.code.targetOS,
+            file: entity.uri,
+            architecture: input.config.code.targetArchitecture,
+          ),
+        );
+        foundFiles.add(entity.uri);
+        addedAssetNames.add(assetName);
+        break; // Only add one file per asset name.
+      }
+    }
+    return foundFiles;
+  }
+
+  /// short for [assets.code.add]
+  void addCodeAsset(CodeAsset codeAsset) {
+    // Only add if we haven't already added this file.
+    if (addedAssets.contains(codeAsset.file)) return;
+    assets.code.add(codeAsset);
+    addedAssets.add(codeAsset.file!);
+  }
 }

--- a/lib/src/utils/add_assets.dart
+++ b/lib/src/utils/add_assets.dart
@@ -8,13 +8,13 @@ import 'package:path/path.dart' as p;
 import '../builder/linkmode.dart';
 
 extension BuildOutputBuilderCodeAssets on BuildOutputBuilder {
-  static final Expando<Set<Uri>> _addedAssets = Expando<Set<Uri>>();
+  static final Expando<Set<String>> _addedAssetIds = Expando<Set<String>>();
 
-  Set<Uri> get addedAssets => _addedAssets[this] ??= <Uri>{};
+  Set<String> get addedAssetIds => _addedAssetIds[this] ??= <String>{};
 
   /// Searches recursively through the provided [outDir] (or [input.outputDirectory]
   /// if not provided) for native library files that match the given [names]
-  /// and adds them to [output.assets.code].
+  /// and adds them to [assets.code].
   ///
   /// [names] are used to map a found library file to package URI.
   /// e.g., for `foo_windows_x64.dll` -> `package:my_pkg/native_foo.dart`,
@@ -30,16 +30,16 @@ extension BuildOutputBuilderCodeAssets on BuildOutputBuilder {
   /// The expected filename is computed using the current operating system's naming conventions
   /// combined with a concrete [LinkMode] derived from [input.config.code.linkModePreference].
   /// For each file that ends with the computed library filename for one of the provided [names],
-  /// a [CodeAsset] is created and added to [output.assets.code] if it hasn't already been added.
+  /// a [CodeAsset] is created and added to [assets.code] if it hasn't already been added.
   ///
   /// Duplicate assets are avoided by tracking previously added file paths internally
-  /// as [output.assets] is not iterable.
+  /// as [assets] is not iterable.
   ///
-  /// Returns a list of URIs corresponding to all the added code assets.
+  /// Returns a list of the added code assets.
   ///
   /// Example:
   /// ```dart
-  /// final foundUris = await addCodeAssets(
+  /// final added = await output.findAndAddCodeAssets(
   ///   input,
   ///   output,
   ///   outDir: myOutputUri,
@@ -48,7 +48,7 @@ extension BuildOutputBuilderCodeAssets on BuildOutputBuilder {
   /// ```
   ///
   /// ```dart
-  /// final foundUris = await addCodeAssets(
+  /// final added = await output.findAndAddCodeAssets(
   ///   input,
   ///   output,
   ///   outDir: myOutputUri,
@@ -56,7 +56,39 @@ extension BuildOutputBuilderCodeAssets on BuildOutputBuilder {
   ///   regExp=true,
   /// );
   /// ```
-  Future<List<Uri>> findAndAddCodeAssets(
+  Future<List<CodeAsset>> findAndAddCodeAssets(
+    BuildInput input, {
+    required Map<String, String> names, // key: search library name, value: dart ffi name
+    Uri? outDir,
+    Logger? logger,
+    bool regExp = false,
+  }) async {
+    final foundAssets = await findCodeAssets(
+      input,
+      names: names,
+      outDir: outDir,
+      logger: logger,
+      regExp: regExp,
+    );
+    final addedAssets = addAllCodeAssets(foundAssets, logger: logger);
+    return addedAssets;
+  }
+
+  /// Finds native library files in the provided [outDir] (or [input.outputDirectory] if not provided)
+  ///
+  /// [names] are used to map a found library file to package URI.
+  /// e.g., for `foo_windows_x64.dll` -> `package:my_pkg/native_foo.dart`,
+  /// should provide `{'foo_windows_x64': 'native_foo.dart'}`.
+  ///
+  /// If [regExp] is true, keys in [names] are treated as regular expression patterns to match library filenames.
+  /// Use regExp if the built libraries are something like `libadd-1.dll`.
+  /// e.g.,
+  /// ```dart
+  /// {r'(lib)?add-\d\.(dll|so|dylib)': 'native_foo.dart'}.
+  /// ```
+  ///
+  /// returns a list of the found code assets.
+  Future<Set<CodeAsset>> findCodeAssets(
     BuildInput input, {
     required Map<String, String> names, // key: search library name, value: dart ffi name
     Uri? outDir,
@@ -66,49 +98,53 @@ extension BuildOutputBuilderCodeAssets on BuildOutputBuilder {
     final preferredMode = input.config.code.linkModePreference;
     final searchDir = Directory.fromUri(outDir ?? input.outputDirectory);
     final linkMode = getLinkMode(preferredMode);
-    final List<Uri> foundFiles = [];
-    // Track the added asset names to prevent duplicates even if the file URIs differ.
-    final Set<String> addedAssetNames = {};
+    final Set<CodeAsset> foundAssets = {};
 
     logger?.info('Searching for libraries in ${searchDir.path}');
     logger?.info('Preferred link mode: $preferredMode');
 
     await for (final entity in searchDir.list(recursive: true, followLinks: false)) {
       if (entity is! File) continue;
-      for (final entry in names.entries) {
-        final key = entry.key;
-        final assetName = entry.value;
-        // Skip if we've already added an asset with this name.
-        if (addedAssetNames.contains(assetName)) continue;
-        final fileName = p.basename(entity.path);
+      for (final MapEntry(:key, value: assetName) in names.entries) {
         final found = regExp
-            ? RegExp(key).hasMatch(fileName)
+            ? RegExp(key).hasMatch(p.basename(entity.path))
             : entity.path.endsWith(OS.current.libraryFileName(key, linkMode));
         if (!found) continue;
         logger?.info('Found library file: ${entity.path}');
-        addCodeAsset(
-          CodeAsset(
-            package: input.packageName,
-            name: assetName,
-            linkMode: linkMode,
-            os: input.config.code.targetOS,
-            file: entity.uri,
-            architecture: input.config.code.targetArchitecture,
-          ),
+        final asset = CodeAsset(
+          package: input.packageName,
+          name: assetName,
+          linkMode: linkMode,
+          os: input.config.code.targetOS,
+          file: entity.uri,
+          architecture: input.config.code.targetArchitecture,
         );
-        foundFiles.add(entity.uri);
-        addedAssetNames.add(assetName);
+        foundAssets.add(asset);
         break; // Only add one file per asset name.
       }
     }
-    return foundFiles;
+    return foundAssets;
   }
 
   /// short for [assets.code.add]
-  void addCodeAsset(CodeAsset codeAsset) {
+  bool addCodeAsset(CodeAsset codeAsset) {
     // Only add if we haven't already added this file.
-    if (addedAssets.contains(codeAsset.file)) return;
+    if (addedAssetIds.contains(codeAsset.id)) return false;
     assets.code.add(codeAsset);
-    addedAssets.add(codeAsset.file!);
+    addedAssetIds.add(codeAsset.id);
+    return true;
+  }
+
+  /// add all code assets, won't add if already added
+  List<CodeAsset> addAllCodeAssets(Iterable<CodeAsset> codeAssets, {Logger? logger}) {
+    final addedAssets = <CodeAsset>[];
+    for (final asset in codeAssets) {
+      logger?.info('Adding asset: $asset');
+      if (!addedAssetIds.contains(asset.id)) {
+        addCodeAsset(asset);
+        addedAssets.add(asset);
+      }
+    }
+    return addedAssets;
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: native_toolchain_cmake
 description: >-
   A library to invoke CMake for Dart Native Assets.
-version: 0.0.3
+version: 0.0.4
 repository: https://github.com/rainyl/native_toolchain_cmake
 
 topics:

--- a/test/builder/cmake_builder_git_test.dart
+++ b/test/builder/cmake_builder_git_test.dart
@@ -1,6 +1,7 @@
 import 'dart:ffi';
 import 'dart:io';
 
+import 'package:logging/logging.dart';
 import 'package:native_toolchain_cmake/native_toolchain_cmake.dart';
 import 'package:native_toolchain_cmake/src/builder/builder.dart';
 import 'package:test/test.dart';
@@ -21,7 +22,7 @@ void main() {
           gitUrl: 'https://github.com/rainyl/native_toolchain_cmake.git',
           sourceDir: tempDir,
           gitSubDir: subdir,
-          // logger: Logger('')..level = Level.ALL..onRecord.listen((record) => stderr.writeln(record)),
+          logger: Logger('')..level = Level.ALL..onRecord.listen((record) => stderr.writeln(record)),
         );
 
         // The builder constructor creates a directory at sourceDir/external/<name>

--- a/test/utils/add_assets_test.dart
+++ b/test/utils/add_assets_test.dart
@@ -42,26 +42,27 @@ void main() {
         );
 
       final buildInput = BuildInput(buildInputBuilder.json);
-      final buildOutput = BuildOutputBuilder();
 
       {
+        final buildOutput = BuildOutputBuilder();
         // Call addLibraries with the provided dynamic library names.
-        final found = await buildOutput.findAndAddCodeAssets(
+        final added = await buildOutput.findAndAddCodeAssets(
           buildInput,
           outDir: baseDir,
           names: {'add': 'add.dart'},
           logger: logger,
         );
 
-        // Validate that one library file was found.
-        expect(found.length, equals(1));
+        // Validate that one library file was added.
+        expect(added.length, equals(1));
         // The file should reside in a "lib" subdirectory.
-        expect(found.first.toFilePath(), equals(libFile.absolute.path));
+        expect(added.first.file?.toFilePath(), equals(libFile.absolute.path));
       }
 
       {
+        final buildOutput = BuildOutputBuilder();
         // Call addLibraries with the provided dynamic library names.
-        final found = await buildOutput.findAndAddCodeAssets(
+        final added = await buildOutput.findAndAddCodeAssets(
           buildInput,
           outDir: baseDir,
           names: {r'(lib)?add\.(dll|so|dylib)': 'add.dart'},
@@ -69,10 +70,10 @@ void main() {
           regExp: true,
         );
 
-        // Validate that one library file was found.
-        expect(found.length, equals(1));
+        // Validate that one library file was added.
+        expect(added.length, equals(1));
         // The file should reside in a "lib" subdirectory.
-        expect(found.first.toFilePath(), equals(libFile.absolute.path));
+        expect(added.first.file?.toFilePath(), equals(libFile.absolute.path));
       }
     });
   });
@@ -110,22 +111,23 @@ void main() {
     final buildOutput = BuildOutputBuilder();
 
     // First call should add the asset.
-    final foundFirst = await buildOutput.findAndAddCodeAssets(
+    final addedFirst = await buildOutput.findAndAddCodeAssets(
       buildInput,
       outDir: baseDir,
       names: {'add': 'add.dart'},
       logger: logger,
     );
-    expect(foundFirst.length, equals(1));
+    expect(addedFirst.length, equals(1));
 
     // Second call should not add the asset again since it's already added.
-    final foundSecond = await buildOutput.findAndAddCodeAssets(
+    final addedSecond = await buildOutput.findAndAddCodeAssets(
       buildInput,
       outDir: baseDir,
       names: {'add': 'add.dart'},
       logger: logger,
     );
-    expect(foundSecond.length, equals(1));
+    // No assets should be added.
+    expect(addedSecond.length, equals(0));
   });
 
   test('does not add duplicate asset when libraries exist in nested directories', () async {
@@ -171,13 +173,13 @@ void main() {
     final buildOutput = BuildOutputBuilder();
 
     // The call should find matching library files but add only one asset.
-    final found = await buildOutput.findAndAddCodeAssets(
+    final added = await buildOutput.findAndAddCodeAssets(
       buildInput,
       outDir: baseDir,
       names: {'add': 'add.dart'},
       logger: logger,
     );
 
-    expect(found.length, equals(1));
+    expect(added.length, equals(1));
   });
 }

--- a/test/utils/add_assets_test.dart
+++ b/test/utils/add_assets_test.dart
@@ -46,9 +46,8 @@ void main() {
 
       {
         // Call addLibraries with the provided dynamic library names.
-        final found = await addFoundCodeAssets(
+        final found = await buildOutput.findAndAddCodeAssets(
           buildInput,
-          buildOutput,
           outDir: baseDir,
           names: {'add': 'add.dart'},
           logger: logger,
@@ -76,5 +75,109 @@ void main() {
         expect(found.first.toFilePath(), equals(libFile.absolute.path));
       }
     });
+  });
+
+  test('does not add duplicate asset for the same library file', () async {
+    // Create temporary directories as URIs.
+    final baseDir = await tempDirForTest();
+    final sharedDir = await tempDirForTest();
+
+    // Create a "lib" subdirectory.
+    final libDir = Directory.fromUri(baseDir.resolve('lib'));
+    await libDir.create();
+
+    // Based on the current OS, create a dummy dynamic library file for the "add" project.
+    final libFileName = OS.current.dylibFileName('add'); // e.g. add.dll, libadd.so, or add.dylib.
+    final libFile = File.fromUri(libDir.uri.resolve(libFileName));
+    await libFile.writeAsString('dummy library content');
+
+    final buildInputBuilder = BuildInputBuilder()
+      ..setupShared(
+        packageName: 'add',
+        packageRoot: baseDir,
+        outputFile: baseDir.resolve('output.json'),
+        outputDirectory: baseDir,
+        outputDirectoryShared: sharedDir,
+      )
+      ..config.setupBuild(linkingEnabled: true, dryRun: false)
+      ..config.setupShared(buildAssetTypes: [CodeAsset.type])
+      ..config.setupCode(
+        targetOS: OS.current,
+        linkModePreference: LinkModePreference.dynamic,
+        targetArchitecture: Architecture.current,
+      );
+    final buildInput = BuildInput(buildInputBuilder.json);
+    final buildOutput = BuildOutputBuilder();
+
+    // First call should add the asset.
+    final foundFirst = await buildOutput.findAndAddCodeAssets(
+      buildInput,
+      outDir: baseDir,
+      names: {'add': 'add.dart'},
+      logger: logger,
+    );
+    expect(foundFirst.length, equals(1));
+
+    // Second call should not add the asset again since it's already added.
+    final foundSecond = await buildOutput.findAndAddCodeAssets(
+      buildInput,
+      outDir: baseDir,
+      names: {'add': 'add.dart'},
+      logger: logger,
+    );
+    expect(foundSecond.length, equals(1));
+  });
+
+  test('does not add duplicate asset when libraries exist in nested directories', () async {
+    // Create temporary directories as URIs.
+    final baseDir = await tempDirForTest();
+    final sharedDir = await tempDirForTest();
+
+    // Create a top-level "lib" subdirectory.
+    final libDir = Directory.fromUri(baseDir.resolve('lib'));
+    await libDir.create();
+
+    // Create a nested subdirectory under "lib".
+    final nestedDir = Directory.fromUri(libDir.uri.resolve('nested'));
+    await nestedDir.create();
+
+    // Determine the dynamic library file name.
+    final libFileName = OS.current.dylibFileName('add');
+
+    // Create a library file in the top-level "lib" directory.
+    final topLibFile = File.fromUri(libDir.uri.resolve(libFileName));
+    await topLibFile.writeAsString('top level library content');
+
+    // Create another library file with the same name in the nested directory.
+    final nestedLibFile = File.fromUri(nestedDir.uri.resolve(libFileName));
+    await nestedLibFile.writeAsString('nested library content');
+
+    final buildInputBuilder = BuildInputBuilder()
+      ..setupShared(
+        packageName: 'add',
+        packageRoot: baseDir,
+        outputFile: baseDir.resolve('output.json'),
+        outputDirectory: baseDir,
+        outputDirectoryShared: sharedDir,
+      )
+      ..config.setupBuild(linkingEnabled: true, dryRun: false)
+      ..config.setupShared(buildAssetTypes: [CodeAsset.type])
+      ..config.setupCode(
+        targetOS: OS.current,
+        linkModePreference: LinkModePreference.dynamic,
+        targetArchitecture: Architecture.current,
+      );
+    final buildInput = BuildInput(buildInputBuilder.json);
+    final buildOutput = BuildOutputBuilder();
+
+    // The call should find matching library files but add only one asset.
+    final found = await buildOutput.findAndAddCodeAssets(
+      buildInput,
+      outDir: baseDir,
+      names: {'add': 'add.dart'},
+      logger: logger,
+    );
+
+    expect(found.length, equals(1));
   });
 }


### PR DESCRIPTION
We need to track assets we add to prevent duplicates, the builder will throw an arrow if findAndAddCodeAssets this tries to add multiple as the same name. Added a couple of test cases for this.