### PR TITLE
Fix null assert blocking tool resolution, use ninja to align with flutter, Fix targetOS instead of OS.current.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,4 @@
   "dart.vmAdditionalArgs": [
     "--enable-experiment=native-assets"
   ],
-  "cmake.sourceDirectory": "D:/Code/git/forks/native_toolchain_cmake/example/add/src"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,5 @@
   "dart.flutterSdkPath": ".fvm/versions/master",
   "dart.vmAdditionalArgs": [
     "--enable-experiment=native-assets"
-  ],
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
   "dart.flutterSdkPath": ".fvm/versions/master",
   "dart.vmAdditionalArgs": [
     "--enable-experiment=native-assets"
-  ]
+  ],
+  "cmake.sourceDirectory": "D:/Code/git/forks/native_toolchain_cmake/example/add/src"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.0.4
 
+- fix: android should use Ninja for android builds
+- fix: fixed a uri resolution issue for the local build folder
+- fix: use the input's target OS instead of current.OS
+- fix: null value in tool resolution
 - new: add extension methods `BuildOutputBuilder.findCodeAssets`, `BuildOutputBuilder.addAllCodeAssets`
 - breaking change: `BuildOutputBuilder.findAndAddCodeAssets` now returns `List<CodeAsset>`
 

--- a/lib/src/builder/builder.dart
+++ b/lib/src/builder/builder.dart
@@ -202,7 +202,8 @@ class CMakeBuilder implements Builder {
     if (outDir == null && buildLocal) {
       final plat = input.config.code.targetOS.name.toLowerCase();
       final arch = input.config.code.targetArchitecture.name.toLowerCase();
-      outDir = sourceDir.resolve('build/').resolve(plat).resolve(arch).normalizePath();
+      outDir = sourceDir.resolve('build/').resolve('$plat/').resolve(arch).normalizePath();
+      stderr.writeln('Using local build directory: $outDir');
     }
     await Directory.fromUri(outDir ?? input.outputDirectory).create(recursive: true);
 

--- a/lib/src/builder/builder.dart
+++ b/lib/src/builder/builder.dart
@@ -203,7 +203,6 @@ class CMakeBuilder implements Builder {
       final plat = input.config.code.targetOS.name.toLowerCase();
       final arch = input.config.code.targetArchitecture.name.toLowerCase();
       outDir = sourceDir.resolve('build/').resolve('$plat/').resolve(arch).normalizePath();
-      stderr.writeln('Using local build directory: $outDir');
     }
     await Directory.fromUri(outDir ?? input.outputDirectory).create(recursive: true);
 

--- a/lib/src/builder/run_builder.dart
+++ b/lib/src/builder/run_builder.dart
@@ -37,7 +37,7 @@ class RunCMakeBuilder {
   final BuildMode buildMode;
 
   /// -G
-  final Generator generator;
+  Generator generator;
 
   /// -T
   final String? toolset;
@@ -228,8 +228,8 @@ class RunCMakeBuilder {
       return [];
     }
     final defs = <String>[];
-    final toolchain = await androidToolchainCmake();
-    defs.add('-DCMAKE_TOOLCHAIN_FILE=${toolchain.normalizePath().toFilePath()}');
+
+    generator == Generator.defaultGenerator ? generator = Generator.ninja : generator = generator;
 
     // The Android Gradle plugin does not honor API level 19 and 20 when
     // invoking clang. Mimic that behavior here.
@@ -268,6 +268,7 @@ class RunCMakeBuilder {
   }
 
   Future<List<String>> _generateLinuxDefines() async {
+    generator == Generator.defaultGenerator ? generator = Generator.ninja : generator = generator;
     if (codeConfig.targetOS != OS.linux) {
       return [];
     }

--- a/lib/src/builder/run_builder.dart
+++ b/lib/src/builder/run_builder.dart
@@ -270,7 +270,6 @@ class RunCMakeBuilder {
   }
 
   Future<List<String>> _generateLinuxDefines() async {
-    generator == Generator.defaultGenerator ? generator = Generator.ninja : generator = generator;
     if (codeConfig.targetOS != OS.linux) {
       return [];
     }

--- a/lib/src/builder/run_builder.dart
+++ b/lib/src/builder/run_builder.dart
@@ -228,6 +228,8 @@ class RunCMakeBuilder {
       return [];
     }
     final defs = <String>[];
+    final toolchain = await androidToolchainCmake();
+    defs.add('-DCMAKE_TOOLCHAIN_FILE=${toolchain.normalizePath().toFilePath()}');
 
     generator == Generator.defaultGenerator ? generator = Generator.ninja : generator = generator;
 

--- a/lib/src/tool/tool_resolver.dart
+++ b/lib/src/tool/tool_resolver.dart
@@ -207,8 +207,9 @@ class InstallLocationResolver implements ToolResolver {
     String pathNew = path;
     if (path.startsWith(home)) {
       final homeDir_ = homeDir;
-      assert(homeDir_ != null);
-      pathNew = path.replaceAll('$home/', homeDir!.toFilePath().replaceAll(r'\', '/'));
+      if (homeDir_ != null) {
+        pathNew = path.replaceAll('$home/', homeDir!.toFilePath().replaceAll(r'\', '/'));
+      }
     }
 
     final result = <Uri>[];

--- a/lib/src/utils/add_assets.dart
+++ b/lib/src/utils/add_assets.dart
@@ -74,7 +74,7 @@ Future<List<Uri>> addFoundCodeAssets(
       // e.g., when using mingw64, so allow using RegExp matching if regExp=true.
       final found = regExp
           ? RegExp(key).hasMatch(p.basename(entity.path))
-          : entity.path.endsWith(OS.current.libraryFileName(key, linkMode));
+          : entity.path.endsWith(input.config.code.targetOS.libraryFileName(key, linkMode));
       if (!found) continue;
       logger?.info('Found library file: ${entity.path}');
       output.addCodeAsset(

--- a/test/builder/cmake_builder_git_test.dart
+++ b/test/builder/cmake_builder_git_test.dart
@@ -22,7 +22,9 @@ void main() {
           gitUrl: 'https://github.com/rainyl/native_toolchain_cmake.git',
           sourceDir: tempDir,
           gitSubDir: subdir,
-          logger: Logger('')..level = Level.ALL..onRecord.listen((record) => stderr.writeln(record)),
+          logger: Logger('')
+            ..level = Level.ALL
+            ..onRecord.listen((record) => stderr.writeln(record)),
         );
 
         // The builder constructor creates a directory at sourceDir/external/<name>
@@ -87,7 +89,8 @@ void main() {
         final osName = input.config.code.targetOS.name.toLowerCase();
         final archName = input.config.code.targetArchitecture.name.toLowerCase();
         final buildDir = buildLocal
-            ? Directory.fromUri(tempDir.resolve('build/').resolve(osName).resolve(archName).normalizePath())
+            ? Directory.fromUri(
+                tempDir.resolve('build/').resolve("$osName/").resolve(archName).normalizePath())
             : Directory.fromUri(input.outputDirectory);
         expect(
           buildDir.existsSync(),


### PR DESCRIPTION
For Android, it would be best if we allowed CMake to determine the NDK instead of resolving the tool and providing it manually. We should use Ninja on Android and Linux instead of default to align with flutter.

fixes #13 