### PR TITLE
Fix runProcess encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # native_toolchain_cmake
 
+## 0.2.5
+
+- fix: add encoding parameter (default is `systemEncoding`) to runProcess for consistent output decoding
+
 ## 0.2.4
 
 - new: add `parallelJobs` and `parallelUseAllProcessors` to support parallel build or set njobs explicitly.

--- a/lib/src/native_toolchain/msvc.dart
+++ b/lib/src/native_toolchain/msvc.dart
@@ -269,6 +269,7 @@ class VisualStudioResolver implements ToolResolver {
         arguments: arguments,
         logger: logger,
         environment: environment,
+        encoding: utf8,
       );
       var toolInfos = json.decode(vswhereResult.stdout) as List;
       // Try again including prerelease versions if no stable versions found.
@@ -278,6 +279,7 @@ class VisualStudioResolver implements ToolResolver {
           arguments: [...arguments, '-prerelease'],
           logger: logger,
           environment: environment,
+          encoding: utf8,
         );
         toolInfos = json.decode(vswhereResult.stdout) as List;
       }

--- a/lib/src/utils/run_process.dart
+++ b/lib/src/utils/run_process.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:logging/logging.dart';
@@ -21,6 +22,7 @@ Future<RunProcessResult> runProcess({
   bool captureOutput = true,
   int expectedExitCode = 0,
   bool throwOnUnexpectedExitCode = false,
+  Encoding encoding = systemEncoding,
 }) async {
   final printWorkingDir = workingDirectory != null && workingDirectory != Directory.current.uri;
   final commandString = [
@@ -42,37 +44,36 @@ Future<RunProcessResult> runProcess({
     runInShell: false,
   );
 
-  final stdoutSub = process.stdout.listen(
-    (List<int> data) {
-      try {
-        final decodedData = systemEncoding.decode(data);
-        logger?.fine(decodedData);
-        if (captureOutput) {
-          stdoutBuffer.write(decodedData);
-        }
-      } catch (e) {
-        logger?.warning('Failed to decode stdout: $e');
-        stdoutBuffer.write('Failed to decode stdout: $e');
+  final stdoutSub = process.stdout.listen((List<int> data) {
+    try {
+      final decodedData = encoding.decode(data);
+      logger?.fine(decodedData);
+      if (captureOutput) {
+        stdoutBuffer.write(decodedData);
       }
-    },
-  );
-  final stderrSub = process.stderr.listen(
-    (List<int> data) {
-      try {
-        final decodedData = systemEncoding.decode(data);
-        logger?.severe(decodedData);
-        if (captureOutput) {
-          stderrBuffer.write(decodedData);
-        }
-      } catch (e) {
-        logger?.severe('Failed to decode stderr: $e');
-        stderrBuffer.write('Failed to decode stderr: $e');
+    } catch (e) {
+      logger?.warning('Failed to decode stdout: $e');
+      stdoutBuffer.write('Failed to decode stdout: $e');
+    }
+  });
+  final stderrSub = process.stderr.listen((List<int> data) {
+    try {
+      final decodedData = encoding.decode(data);
+      logger?.severe(decodedData);
+      if (captureOutput) {
+        stderrBuffer.write(decodedData);
       }
-    },
-  );
+    } catch (e) {
+      logger?.severe('Failed to decode stderr: $e');
+      stderrBuffer.write('Failed to decode stderr: $e');
+    }
+  });
 
-  final (exitCode, _, _) =
-      await (process.exitCode, stdoutSub.asFuture<void>(), stderrSub.asFuture<void>()).wait;
+  final (exitCode, _, _) = await (
+    process.exitCode,
+    stdoutSub.asFuture<void>(),
+    stderrSub.asFuture<void>(),
+  ).wait;
 
   await stdoutSub.cancel();
   await stderrSub.cancel();
@@ -172,7 +173,8 @@ class RunProcessResult {
   });
 
   @override
-  String toString() => '''command: $command
+  String toString() =>
+      '''command: $command
 exitCode: $exitCode
 stdout: $stdout
 stderr: $stderr''';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: native_toolchain_cmake
 description: >-
   A library to invoke and build CMake projects for Dart Native Assets.
-version: 0.2.4
+version: 0.2.5
 repository: https://github.com/rainyl/native_toolchain_cmake
 
 topics:


### PR DESCRIPTION
fix: add `encoding` parameter to `runProcess`, use `utf8` to decode `vswhere.exe` outputs, which fixes the encoding error on non-utf8 (e.g., GBK2312) code pages.